### PR TITLE
Correct C++17 if-with-initializer example

### DIFF
--- a/_posts/2018-03-15-totw-141.md
+++ b/_posts/2018-03-15-totw-141.md
@@ -104,8 +104,8 @@ if (absl::optional<Foo> foo = MaybeFoo()) {
 However, avoid this pattern if the underlying type is implicitly convertible to
 `bool`.
 
-In C++17, `if` statements can contain an initializer, so the scope of the
-declaration can be limited while avoiding the implicit conversion:
+**Note:** In C++17, `if` statements can contain an initializer, so the scope of
+the declaration can be limited while avoiding the implicit conversion:
 
 ```c++
 if (absl::optional<Foo> foo = MaybeFoo(); foo.has_value()) {

--- a/_posts/2018-03-15-totw-141.md
+++ b/_posts/2018-03-15-totw-141.md
@@ -99,15 +99,19 @@ of the variable, but involves an implicit conversion to `bool`:
 if (absl::optional<Foo> foo = MaybeFoo()) {
   DoSomething(*foo);
 }
-
-# Note: in C++17, the above can more compactly be expressed using an
-# "if statement with initializer":
-
-if (absl::optional<Foo> foo = MaybeFoo(); DoSomething(*foo));
 ```
 
 However, avoid this pattern if the underlying type is implicitly convertible to
 `bool`.
+
+In C++17, `if` statements can contain an initializer, so the scope of the
+declaration can be limited while avoiding the implicit conversion:
+
+```c++
+if (absl::optional<Foo> foo = MaybeFoo(); foo.has_value()) {
+  DoSomething(*foo);
+}
+```
 
 ## "Boolean-like" Enums
 


### PR DESCRIPTION
The current example is incorrect. The code in that example should call DoSomething(*foo) only if the optional value is populated, while avoiding a broad variable scope for the optional and an implicit conversion when checking that the optional is not empty.